### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,7 +12,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
     # 次と前の商品表示の為の記述はじまり
     @previous_item = Item.where('id < ?', @item.id).order(id: :desc).first
     @next_item = Item.where('id > ?', @item.id).order(id: :asc).first
@@ -22,7 +21,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user == @item.user
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create] # ← , :edit, :update, :destroy を編集・消去機能実装時に追加
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update] # ← :destroy を編集・消去機能実装時に追加
   before_action :set_item, only: [:show] # ←:edit, :update 詳細・編集機能実装時に追加
 
   # 後ほど実装する(一覧)
@@ -22,19 +22,19 @@ class ItemsController < ApplicationController
   end
 
   # 後ほど実装する(編集)
-  # def edit
-  #   # 出品者以外はトップページへリダイレクト
-  #   redirect_to root_path unless current_user == @item.user
-  # end
+  def edit
+    # 出品者以外はトップページへリダイレクト
+    redirect_to root_path unless current_user == @item.user
+  end
 
   # 後ほど実装する(編集)
-  # def update
-  #   if @item.update(item_params)
-  #     redirect_to item_path(@item)
-  #   else
-  #     render :edit, status: :unprocessable_entity
-  #   end
-  # end
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   def create
     @item = Item.new(item_params)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update] # ← :destroy を編集・消去機能実装時に追加
-  before_action :set_item, only: [:show] # ←:edit, :update 詳細・編集機能実装時に追加
+  before_action :set_item, only: [:show, :edit, :update]
 
   # 後ほど実装する(一覧)
   def index
@@ -21,13 +21,11 @@ class ItemsController < ApplicationController
     # 次と前の商品表示の為の記述終わり
   end
 
-  # 後ほど実装する(編集)
   def edit
-    # 出品者以外はトップページへリダイレクト
+    @item = Item.find(params[:id])
     redirect_to root_path unless current_user == @item.user
   end
 
-  # 後ほど実装する(編集)
   def update
     if @item.update(item_params)
       redirect_to item_path(@item)

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,9 +8,7 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -6,7 +6,7 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
@@ -22,7 +22,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -32,13 +32,13 @@
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -51,12 +51,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:sales_status_id, SalesStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -72,17 +72,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -100,7 +100,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -140,7 +140,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 <% if user_signed_in? %>
   <% if current_user == @item.user %>
     <!-- 出品者自身の場合（編集・削除ボタン） -->
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   root to: 'items#index'
   get "up" => "rails/health#show", as: :rails_health_check
-  resources :items, only: [:index, :new, :create, :show]#← :edit, :update, :destroyを後で追加
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]#← , :destroyを後で追加
 end


### PR DESCRIPTION
## 【What】商品情報編集機能実装
-  ログイン状態の出品者は商品情報編集ページに遷移できる動画 { https://gyazo.com/3ad96cb8648713107e3f7bfb29bdf58a }

-  「更新する」ボタンを押すと、商品の情報を編集できる動画 { https://gyazo.com/f47097f0897362c2c0a8251a9f2f0135 }

-  入力に問題が場合、情報は保存されず、エラーメッセージが表示される動画 { https://gyazo.com/137a6566c4a0ed42e1e5fe68b365438d }

-  何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画 { https://gyazo.com/8b8226d0be5fd91b31fa9677b0465224 }

-  URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとするとトップページに遷移する動画 { https://gyazo.com/7950d1ec57aff5b23551ad4870c26997 }

-  ~自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画~ { 商品購入機能で実装予定の為なし }

-  ログアウト状態の場合は商品の販売状況に関わらずログインページに遷移する動画  { https://gyazo.com/d20687583a584a314a3c1c0bd8ebc9c6 }


##  【why】コードレニューの為
- 売却済み・消去済み等の動作に関しては次以降の実装で行う為未実装